### PR TITLE
Fix/doubleext

### DIFF
--- a/bio/db/tator_db.py
+++ b/bio/db/tator_db.py
@@ -203,11 +203,11 @@ def download_data(api: tator.api,
         all_media = get_media(api, project_id, media_ids)
 
         # Get all the unique media names
-        def get_media_stem(media_filename: str) -> str:
-            parts = media_filename.stem.rsplit('.', 1)
+        def get_media_stem(media_path: Path) -> str:
+            parts = media_path.stem.rsplit('.', 1)
             return '.'.join(parts)
 
-        media_names = list(set([get_media_stem(m.name) for m in all_media]))
+        media_names = list(set([get_media_stem(m) for m in all_media]))
 
         # Get all the unique Label attributes and sort them alphabetically
         labels = list(sorted(set([l.attributes['Label'] for l in localizations])))
@@ -245,7 +245,7 @@ def download_data(api: tator.api,
         for media_name in media_names:
 
             # Get the media object
-            media = [m for m in all_media if get_media_stem(m.name) == media_name][0]
+            media = [m for m in all_media if get_media_stem(m) == media_name][0]
 
             # Get all the localizations for this media
             media_localizations = [l for l in localizations if l.media == media.id]

--- a/bio/db/tator_db.py
+++ b/bio/db/tator_db.py
@@ -204,7 +204,7 @@ def download_data(api: tator.api,
 
         # Get all the unique media names
         def get_media_stem(media_path: Path) -> str:
-            parts = media_path.stem.rsplit('.', 1)
+            parts = Path(media_path.name).stem.rsplit('.', 1)
             return '.'.join(parts)
 
         media_names = list(set([get_media_stem(m) for m in all_media]))

--- a/bio/db/tator_db.py
+++ b/bio/db/tator_db.py
@@ -203,7 +203,11 @@ def download_data(api: tator.api,
         all_media = get_media(api, project_id, media_ids)
 
         # Get all the unique media names
-        media_names = list(set([m.name.split('.png')[0] for m in all_media]))
+        def get_media_stem(media_filename: str) -> str:
+            parts = media_filename.stem.rsplit('.', 1)
+            return '.'.join(parts)
+
+        media_names = list(set([get_media_stem(m.name) for m in all_media]))
 
         # Get all the unique Label attributes and sort them alphabetically
         labels = list(sorted(set([l.attributes['Label'] for l in localizations])))
@@ -241,7 +245,7 @@ def download_data(api: tator.api,
         for media_name in media_names:
 
             # Get the media object
-            media = [m for m in all_media if m.name.split('.png')[0] == media_name][0]
+            media = [m for m in all_media if get_media_stem(m.name) == media_name][0]
 
             # Get all the localizations for this media
             media_localizations = [l for l in localizations if l.media == media.id]


### PR DESCRIPTION
This fix supports the weird filenames generated with the [albumentations](https://pypi.org/project/albumentations/) library, e.g.  Ctenophora_sp_A_original_Ctenophora_sp_A-T1036-08_49_49_14.png_772f47d0-fe52-4fd0-9492-f47000d9c2e2.png' which fouled up the data export as the Path object stem did no grok the additional .png.

Tested by downloading with 

```python3 bio.py download --group CTENOPHORA_SP_A --version Baseline```

then running the split command with the deepsea-ai module.